### PR TITLE
Implement psetv, add restarts, add tests, document in readme

### DIFF
--- a/README.org
+++ b/README.org
@@ -9,7 +9,7 @@
   If you encounter something that doesnt work as you think it should, please open an issue here. If you describe the exhibited behavior and the expected behavior, it will be added to the test suite and fixed (hopefully quickly). 
 
 * Usage
-  The basic usage of this system is through the macros ~defconfig~, ~setv~ and ~with-atomic-setv~. The macro ~defconfig~ defines a configuration object which is used to check values against a predicate. The macro ~setv~ uses these configuration objects to validate values before calling setf. An error is signalled if A) the value is invalid, B) the coerced value is invalid (when applicable) or C) the place one is trying to set doesnt have a configuration object. For A and B, restarts are put into place to ignore the invalidity and set regardless. The macro ~with-atomic-setv~ collects all places set with ~setv~ in its body and if an error is signalled resets all changed values back to their original value held before the ~with-atomic-setv~ form. 
+  The basic usage of this system is through the macros ~defconfig~, ~setv~ and ~with-atomic-setv~. The macro ~defconfig~ defines a configuration object which is used to check values against a predicate. The macro ~setv~ uses these configuration objects to validate values before calling setf. An error is signalled if A) the value is invalid, B) the coerced value is invalid (when applicable) or C) the place one is trying to set doesnt have a configuration object. For A and B, restarts are put into place to ignore the invalidity and set regardless, or continue without setting. The macro ~with-atomic-setv~ collects all places set with ~setv~ in its body and if an error is signalled resets all changed values back to their original value held before the ~with-atomic-setv~ form. 
 
 * Regarding This Readme
   This readme is not a complete explanation of defconfig. Please see =package.lisp= for a list of exported symbols and see the symbol docstrings for a better idea of what it does. Most (exported) symbols are well documented, slots have decent documentation describing their purpose/use, and errors should be grokkable from their ~:report~ functions.
@@ -121,6 +121,23 @@
   (setf (var) 1) ; works
   (setv (var) 2) ; tries to find config for the accessor var, not the variable *var*
 #+END_SRC
+** Psetv
+   The macro ~psetv~ is a ~setv~ equivalent of ~psetf~. However, while bindings are "preserved" throughout the form, if an error occurs and there is a non-local transfer of control, any places being set after the error will not be set. An example from the test suite: 
+#+BEGIN_SRC lisp
+  (defconfig-minimal *a* 'a
+    :typespec 'symbol)
+
+  (defconfig-minimal *b* "b"
+    :typespec 'string)
+
+  (defconfig-minimal *c* 'c
+    :typespec 'symbol)
+
+  (psetv *a* *c*
+         *b* *a*
+         *c* *a*)
+#+END_SRC
+   If one enters this in a repl, an error condition will be signalled upon trying to set ~*b*~ to ~'a~, and if one chooses to abort (via ~q~, or ~sly-db-abort~) then ~*c*~ will retain the value ~'c~, and ~*b*~ ~"b"~. 
 ** ~With-atomic-setv~
    The star variant of ~with-atomic-setv~ has a quirk in that places get evaluated multiple times if one resets, while both variants evaluate accessors multiple times. Some code to demonstrate:
 #+BEGIN_SRC lisp
@@ -197,10 +214,15 @@
      - May cause /place/ to be defined as a dynamic variable
      - Any side effects of running /validator/
 ** ~Setv~
-   The ~setv~ macro expands into multiple calls to ~%setv~, which validates a value before setting the place to it. It functions the same as ~setf~, but accepts the keyword ~:db~ to specify a database other than the default one provided by ~defconfig~. Returns the final value. 
+   The ~setv~ macro expands into multiple calls to ~%%setv~, which validates a value before setting the place to it. It functions the same as ~setf~, but accepts the keyword ~:db~ to specify a database other than the default one provided by ~defconfig~. Returns the final value. 
    - *Side Effects*:
      - Any side effects of evaluating a value. Place/value pairs are evaluated sequentially. If a value is not valid, no further values will be processed.
      - Causes /place/ to be set to /value/ 
+** ~Psetv~
+   The ~psetv~ macro expands into multiple calls to ~%%setv~, the same as ~setv~, but differs in that all values are computed before setting, giving the illusion of setting in parallel (similar to ~psetf~).
+   - Side Effects:
+     - Any side effects of evaluating a value. Place/value pairs are evaluated sequentially. If a value is not valid, no further values will be processed.
+     - Causes /place/ to be set to /value/
 ** ~With-atomic-setv/*~
    There are two versions of this macro:  ~with-atomic-setv~ and ~with-atomic-setv*~. The former tracks places and values purely at runtime, while the latter tracks places at macroexpansion time and values at runtime. 
 

--- a/package.lisp
+++ b/package.lisp
@@ -12,6 +12,7 @@
 	   
 	   ;; setters and searchers
 	   #:setv
+           #:psetv
            #:with-atomic-setv
 	   #:with-atomic-setv*
 	   #:reset-place

--- a/setv.lisp
+++ b/setv.lisp
@@ -49,13 +49,16 @@ variable via destructuring-bind."
 	 ,@body))))
 
 (defmacro %setv-ensure-setf (place value config-info-object)
-  `(progn ,(if (listp place)
-	       `(setf ,place ,value)
-	       `(psetf ,place ,value
-		       (config-info-prev-value ,config-info-object) ,place))
-	  ,value))
+  (alexandria:with-gensyms (holdover)
+    `(progn ,(if (listp place)
+                 `(setf ,place ,value)
+                 `(let ((,holdover ,place))
+                    (setf ,place ,value)
+                    (when (typep ,config-info-object 'config-info)
+                      (setf (config-info-prev-value ,config-info-object) ,holdover))))
+            ,value)))
 
-(defun %fsetv-ensure-validity (config-info-object value invalid-symbol
+(defun %fsetv-ensure-validity (throwtag config-info-object value invalid-symbol
 			       &optional errorp place error extra-args)
   "check VALUE against CONFIG-INFO-OBJECTs predicate. return VALUE if it passes.
 If ERRORP is true error if VALUE doesnt pass. If ERRORP is nil and VALUE doesnt 
@@ -77,6 +80,10 @@ regardless."
 				   :place real-place
 				   :value value)))
 		(t invalid-symbol)))
+      (continue ()
+        :report (lambda (s)
+                  (format s "Return NIL without setting ~A" real-place))
+        (throw throwtag nil))
       (use-value (provided)
 	:test (lambda (c) (typep c 'invalid-datum-error))
 	:report (lambda (s)
@@ -95,22 +102,23 @@ regardless."
 		       (format *query-io* "Enter Value:  ")
 		       (force-output *query-io*)
 		       (list (read *query-io*)))
-	(%fsetv-ensure-validity config-info-object provided invalid-symbol
-				errorp real-place))
+	(%fsetv-ensure-validity throwtag config-info-object provided
+                                invalid-symbol errorp real-place))
       (set-regardless ()
 	:test (lambda (c) (typep c 'invalid-datum-error))
 	:report (lambda (s) (format s "Regardless of validity, set ~S to ~S"
 				    real-place value))
 	(return-from %fsetv-ensure-validity value)))))
 
-(defmacro %%setv-coerced (place value config-object coercer)
+(defmacro %%setv-coerced (place value config-object coercer throwtag)
   (alexandria:with-gensyms (coer-hold validated-value invalid-sym)
     `(if ,coercer 
 	 (let* ((,coer-hold (funcall ,coercer ,value))
 		(,validated-value
-		  (%fsetv-ensure-validity ,config-object ,coer-hold ',invalid-sym
-					  t ',place 'invalid-coerced-datum-error
-					  (list :coerced-value ,coer-hold))))
+		  (%fsetv-ensure-validity ,throwtag ,config-object ,coer-hold
+                                          ',invalid-sym t ',place
+                                          'invalid-coerced-datum-error
+                                          (list :coerced-value ,coer-hold))))
 	   ;; we dont need to check ,validated-values here as we will ALWAYS error
 	   ;; if we get a invalid coerced data. 
 	   (%setv-ensure-setf ,place ,validated-value ,config-object))
@@ -149,17 +157,17 @@ to be provided if were calling this in a setv expansion."
 			   :place place :db 'all-registered-databases)))))))))
 
 (defmacro %%setv (place value db)
-  (alexandria:with-gensyms (hold hash config-info-object invalid-sym
+  (alexandria:with-gensyms (hold hash config-info-object invalid-sym 
 				 validated-value coer setf?-sym block)
     `(let ((,hold ,value))
-       (block ,block 
-	 (let* ((,hash ,(if (listp place) `(car ,db) `(cdr ,db)))
+       (catch ',block
+         (let* ((,hash ,(if (listp place) `(car ,db) `(cdr ,db)))
 		(,config-info-object
 		  (let ((obj (%fsetv-get-config-info-object ',place ,hash ',db
 							    ',setf?-sym)))
 		    (if (eql obj ',setf?-sym)
 			(progn (setf ,place ,hold)
-			       (return-from ,block ,hold))
+			       (throw ',block ,hold))
 			obj)))
 		(,coer (config-info-coercer ,config-info-object))
 		(,validated-value
@@ -167,10 +175,10 @@ to be provided if were calling this in a setv expansion."
 		  ;; if there is a coercer for the place we will return invalid-sym
 		  ;; when ,hold is invalid, and if not we will error out with
 		  ;; restarts in place to provide a value or set regardless
-		  (%fsetv-ensure-validity ,config-info-object ,hold ',invalid-sym
-					  (not ,coer) ',place)))
+		  (%fsetv-ensure-validity ',block ,config-info-object ,hold
+                                          ',invalid-sym (not ,coer) ',place)))
 	   (if (eql ,validated-value ',invalid-sym)
-	       (%%setv-coerced ,place ,hold ,config-info-object ,coer)
+	       (%%setv-coerced ,place ,hold ,config-info-object ,coer ',block)
 	       (%setv-ensure-setf ,place ,validated-value ,config-info-object)))))))
 
 (defmacro setv (&rest args)
@@ -202,6 +210,21 @@ resignalled. It is generally advisable to use WITH-ATOMIC-SETV instead."
 		       for gensym in syms
 		       collect `(setf ,place ,gensym))
 	       (error ,c))))))))
+
+(defmacro %psetv (db pairs)
+  (let ((gensyms (loop for x in pairs collect (gensym "NEW"))))
+    `(let* ,(loop for (p v) on pairs by 'cddr
+                  for gensym in gensyms
+                  collect `(,gensym ,v))
+       ,@(loop for (p v) on pairs by 'cddr
+               for gensym in gensyms
+               collect `(%%setv ,p ,gensym ,db))
+       nil)))
+
+(defmacro psetv (&rest args)
+  "The setv equivalent of psetf - set all places in parallel"
+  (destructuring-keys (pairs (:db '*default-db*)) args
+    `(%psetv ,db ,pairs)))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; Compile-time with-atomic-setv ;;;

--- a/tests/defconfig-tests.lisp
+++ b/tests/defconfig-tests.lisp
@@ -5,7 +5,7 @@
 		#:make-config-database #:reset-place #:with-atomic-setv*
 		#:define-defconfig-db #:get-db #:delete-db #:*setv-permissiveness*
 		#:define-accessor-config #:define-minimal-config
-		#:defconfig-minimal)
+		#:defconfig-minimal #:psetv)
   (:import-from #:fiveam #:is #:signals))
 
 (in-package :defconfig/tests)
@@ -422,3 +422,33 @@
   (signals defconfig:config-error
     (setv *min* 300))
   (is (= *min* 0)))
+
+(defconfig-minimal *a* 'a
+  :typespec 'symbol)
+
+(defconfig-minimal *b* "b"
+  :typespec 'string)
+
+(defconfig-minimal *c* 'c
+  :typespec 'symbol)
+
+(fiveam:test test-psetv
+  (is (and (eql *a* 'a)
+           (eql *c* 'c)))
+  (psetv *a* *c*
+         *c* *a*)
+  (is (and (eql *a* 'c)
+           (eql *c* 'a)))
+  (signals defconfig:invalid-datum-error
+    (psetv *a* *c*
+           *b* *a*
+           *c* *a*))
+  (is (and (eql *a* 'a)
+           (string= *b* "b")
+           (eql *c* 'a)))
+  (psetv *a* 'a
+         *c* 'c
+         *b* "b")
+  (is (and (eql *a* 'a)
+           (string= *b* "b")
+           (eql *c* 'c))))


### PR DESCRIPTION
Implemented psetv, the setv equivalent of psetf, and exported
it. added a continue restart when setv-ing values, and introduced a
catch (changed from a block) used by the continue restart.

added tests for psetv.

documented psetv in readme and gave examples of usage.