### PR TITLE
add database selectability and database creation error handling

### DIFF
--- a/README.org
+++ b/README.org
@@ -217,19 +217,22 @@
      - May cause /place/ to be defined as a dynamic variable
      - Any side effects of running /validator/
 ** ~Setv~
+   *setv* {/place/ /value/}* /:db/  => /result/
    The ~setv~ macro expands into multiple calls to ~%%setv~, which validates a value before setting the place to it. It functions the same as ~setf~, but accepts the keyword ~:db~ to specify a database other than the default one provided by ~defconfig~. Returns the final value. 
    - *Side Effects*:
      - Any side effects of evaluating a value. Place/value pairs are evaluated sequentially. If a value is not valid, no further values will be processed.
      - Causes /place/ to be set to /value/ 
 ** ~Psetv~
+   *psetv* {/place/ /value/}* /:db/ => /result/
    The ~psetv~ macro expands into multiple calls to ~%%setv~, the same as ~setv~, but differs in that all values are computed before setting, giving the illusion of setting in parallel (similar to ~psetf~).
    - Side Effects:
      - Any side effects of evaluating a value. Place/value pairs are evaluated sequentially. If a value is not valid, no further values will be processed.
      - Causes /place/ to be set to /value/
 ** ~With-atomic-setv/*~
+   *with-atomic-setv* (/errorp/ /handle-conditions/ /db/) /form*/ => /results/
    There are two versions of this macro:  ~with-atomic-setv~ and ~with-atomic-setv*~. The former tracks places and values purely at runtime, while the latter tracks places at macroexpansion time and values at runtime. 
 
-   The ~with-atomic-setv~ macro resets any places set using ~setv~ to the value it held before the call to ~with-atomic-setv~, when a condition is encountered. One can specify whether to re-signal the condition or not with ~:errorp~. If ~:errorp~ is nil a warning will be issued on encountering a handled condition and the condition will be returned. Re-signalled conditions are wrapped in the condition ~setv-wrapped-error~. One can specify which conditions to handle with ~:handle-conditions~, which accepts an (unquoted) type specifier. One can handle no conditions by passing ~(or)~, though that defeats the purpose of ~with-atomic-setv~. 
+   The ~with-atomic-setv~ macro resets any places set using ~setv~ to the value it held before the call to ~with-atomic-setv~, when a condition is encountered. One can specify whether to re-signal the condition or not with ~:errorp~. If ~:errorp~ is nil a warning will be issued on encountering a handled condition and the condition will be returned. Re-signalled conditions are wrapped in the condition ~setv-wrapped-error~. One can specify which conditions to handle with ~:handle-conditions~, which accepts an (unquoted) type specifier. One can handle no conditions by passing ~(or)~, though that defeats the purpose of ~with-atomic-setv~. The default database to use for all calls to ~setv~ occuring within /form*/ can be controleld with ~:db~. It defaults to ~defconfig:*default-db*~. 
    
    An example: 
 #+BEGIN_SRC lisp
@@ -262,6 +265,11 @@
   WARNING: hello
   => #<SIMPLE-WARNING "hello" {address}>
 #+END_SRC
+
+** ~Define-defconfig-db~
+   *define-defconfig-db* /var/ /key/ /&key/ /parameter/ /if-exists/ /doc/
+
+   The ~define-defconfig-db~ macro defines a new dynamic variable containing a defconfig database and stores that database internally such that it can be referenced via /key/. All databases used with defconfig should be created using this macro. The key argument /parameter/ defaults to true, and controls whether the database is defined using ~defvar~ or ~defparameter~. Variable documentation is added via the /doc/ key argument. When a key already denotes a defconfig database, an error will be signalled. This can be handled by setting /if-exists/ to ~:use~ or ~redefine~, to either use the existing database or redefine the database respectively. When /if-exists/ is nil the error will propogate up to the user. 
 
 * Help Wanted
   Currently, Travis is being used for CI. However, these builds sometimes fail for unknown reasons unrelated to the defconfig test suite. It would be nice to be able to detect these failures and re-run the job upon encountering them. 

--- a/conditions.lisp
+++ b/conditions.lisp
@@ -7,6 +7,8 @@
 to catch all defconfig conditions (such as with handler-case) then config-error 
 should be used."))
 
+(define-condition with-atomic-setv-internal-error (config-error) ())
+
 (define-condition invalid-datum-error (config-error)
   ((place-form :initarg :place :reader invalid-datum-error-place :initform nil)
    (value :initarg :value :reader invalid-datum-error-value :initform nil)

--- a/database.lisp
+++ b/database.lisp
@@ -124,4 +124,4 @@ the def(parameter|var) form."
 
 (define-defconfig-db *default-db* :default
   :doc "The default database for defconfig"
-  :if-exists :redefine)
+  :if-exists :use)

--- a/defconfig.asd
+++ b/defconfig.asd
@@ -7,7 +7,7 @@
   :version "1.1.2"
   :serial t
   :depends-on (#:alexandria
-               #:trivial-cltl2)
+               #-clisp #:trivial-cltl2)
   :components ((:file "package")
 	       (:file "macros")
 	       (:file "database")

--- a/defconfig.lisp
+++ b/defconfig.lisp
@@ -18,6 +18,7 @@
 
 (defmacro define-minimal-config (place &key (type :accessor) validator typespec
 					 coercer db regen-config)
+  "define a minimal config object for PLACE and in DB."
   (when (and validator typespec)
     (error "The arguments :VALIDATOR and :TYPESPEC cannot both be supplied"))
   `(define-min ,(if (and (eq type :accessor) (symbolp place))
@@ -31,6 +32,7 @@
      :regen-config ,regen-config))
 
 (defmacro defconfig-minimal (place &rest args)
+  "Define a minimal config, with no value tracking."
   (cond ((consp place)
 	 `(define-minimal-config ,place ,@args))
 	((and (keywordp (car args)) (not (keywordp (cadr args)))) 

--- a/tests/defconfig-tests.lisp
+++ b/tests/defconfig-tests.lisp
@@ -466,3 +466,21 @@
 
 (fiveam:test test-predicateless
   (defconfig *mytester* 'mytester))
+
+(fiveam:test test-w-a-s-use-default-db
+  (setv *bounded-number* 0
+        *other-bounded-number* 0
+        :db *testing-db*)
+  (setv *setv-permissiveness* :strict)
+  (is (and (= *bounded-number* 0)
+           (= *other-bounded-number* 0)))
+  (with-atomic-setv (:db *testing-db*)
+    (setv *bounded-number* 2)
+    (setv *other-bounded-number* 1))
+  (is (and (= *bounded-number* 2)
+           (= *other-bounded-number* 1)))
+  (with-atomic-setv* (:db *testing-db*)
+    (setv *bounded-number* 0)
+    (setv *other-bounded-number* 0))
+  (is (and (= *bounded-number* 0)
+           (= *other-bounded-number* 0))))


### PR DESCRIPTION
add the ability to specify a default database for with-atomic-setv/*. add a :if-exists keyarg to define-defconfig-db. 